### PR TITLE
Docs standards for Core Color and Image Upload controls

### DIFF
--- a/customizer/add-controls-core-advanced.php
+++ b/customizer/add-controls-core-advanced.php
@@ -2,28 +2,25 @@
 /**
  * Customizer: Add Controls: Advanced
  *
- * This file demonstrates how to add 
- * advanced core controls to the Customizer. The 
- * Customizer API includes advanced controls for 
- * the following control types:
+ * This file demonstrates how to add advanced core controls to the Customizer. TheCustomizer API
+ * includes advanced controls for the following control types:
  * - WP_Customize_Color_Control 
  * - WP_Customize_Image_Control 
  * 
- * @package 	code-examples
- * @copyright	Copyright (c) 2015, WordPress Theme Review Team
- * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
+ * @package code-examples
+ * @copyright Copyright (c) 2015, WordPress Theme Review Team
+ * @license http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
  */
  
 
 /**
  * Theme Options Customizer Implementation
  *
- * Implement the Theme Customizer for 
- * Theme Settings.
+ * Implement the Theme Customizer for Theme Settings.
+ *
+ * @link http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/
  * 
- * @param 	object	$wp_customize	Object that holds the customizer data
- * 
- * @link	http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/	Otto
+ * @param WP_Customize $wp_customize Object that holds the customizer data.
  */
 function theme_slug_register_customizer_controls_advanced( $wp_customize ){
 
@@ -33,24 +30,21 @@ function theme_slug_register_customizer_controls_advanced( $wp_customize ){
 	if ( ! isset( $wp_customize ) ) {
 		return;
 	}
-	
-	
+
 	/**
-	 * Control: Color 
-	 * Setting: Link Color
-	 * Sanitization: hex_color
+	 * Core Color control.
+	 *
+	 * - Control: Color
+	 * - Setting: Link Color
+	 * - Sanitization: hex_color
 	 * 
-	 * Register "WP_Customize_Color_Control" to be 
-	 * used to configure the Link Color setting.
+	 * Register "WP_Customize_Color_Control" to be used to configure the Link Color setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 * 
-	 * @uses	WP_Customize_Color_Control()	https://developer.wordpress.org/reference/classes/wp_customize_color_control/
-	 * @link	WP_Customize_Color_Control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Color_Control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses WP_Customize_Color_Control() https://developer.wordpress.org/reference/classes/wp_customize_color_control/
+	 * @link WP_Customize_Color_Control() https://codex.wordpress.org/Class_Reference/WP_Customize_Color_Control
 	 */
 	$wp_customize->add_control(
 		new WP_Customize_Color_Control( 
@@ -70,21 +64,19 @@ function theme_slug_register_customizer_controls_advanced( $wp_customize ){
 	
 	
 	/**
+	 * Image Upload control.
+	 *
 	 * Control: Image Upload 
 	 * Setting: Site Logo
 	 * Sanitization: image  
 	 * 
-	 * Register "WP_Customize_Color_Control" to be 
-	 * used to configure the Link Color setting.
+	 * Register "WP_Customize_Color_Control" to be used to configure the Link Color setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 * 
-	 * @uses	WP_Customize_Image_Control()	https://developer.wordpress.org/reference/classes/wp_customize_image_control/
-	 * @link	WP_Customize_Image_Control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Image_Control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses WP_Customize_Image_Control() https://developer.wordpress.org/reference/classes/wp_customize_image_control/
+	 * @link WP_Customize_Image_Control() https://codex.wordpress.org/Class_Reference/WP_Customize_Image_Control
 	 */
 	$wp_customize->add_control(
 		new WP_Customize_Image_Control( 
@@ -103,5 +95,5 @@ function theme_slug_register_customizer_controls_advanced( $wp_customize ){
 	);
 
 }
-// Settings API options initilization and validation
+// Settings API options initilization and validation.
 add_action( 'customize_register', 'theme_slug_register_customizer_controls_advanced' );

--- a/customizer/add-controls-core-advanced.php
+++ b/customizer/add-controls-core-advanced.php
@@ -20,7 +20,7 @@
  *
  * @link http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/
  * 
- * @param WP_Customize $wp_customize Object that holds the customizer data.
+ * @param WP_Customize_Manager $wp_customize Object that holds the customizer data.
  */
 function theme_slug_register_customizer_controls_advanced( $wp_customize ){
 


### PR DESCRIPTION
Docs wrapping, spacing, standards improvements. Within DocBlocks, elements should spaced apart, not tabbed apart. Plays much nicer with GitHub formatting too.

And since the `@uses` `@link` stuff in the multi-line comment above the control seem helpful, I left the opening line as a DocBlock style so IDE's could link up the methods.