### PR TITLE
Docs standards for Basic controls

### DIFF
--- a/customizer/add-controls-core-basic.php
+++ b/customizer/add-controls-core-basic.php
@@ -2,11 +2,9 @@
 /**
  * Customizer: Add Controls: Basic
  *
- * This file demonstrates how to add 
- * basic core controls to the Customizer. 
+ * This file demonstrates how to add basic core controls to the Customizer.
  * 
- * The Customizer API includes basic controls 
- * for the following control types:
+ * The Customizer API includes basic controls for the following control types:
  * - basic: checkbox 
  * - basic: dropdown pages
  * - basic: radio 
@@ -14,9 +12,7 @@
  * - basic: text 
  * - basic: textarea 
  * 
- * WordPress 4.0 also introduced controls 
- * for the following specialized text 
- * input control types:
+ * WordPress 4.0 also introduced controls for the following specialized text input control types:
  * - text: email
  * - text: number 
  * - text: password (not included here)
@@ -24,21 +20,20 @@
  * - text: tel 
  * - text: url 
  * 
- * @package 	code-examples
- * @copyright	Copyright (c) 2015, WordPress Theme Review Team
- * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
+ * @package   code-examples
+ * @copyright Copyright (c) 2015, WordPress Theme Review Team
+ * @license   http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
  */
  
 
 /**
- * Theme Options Customizer Implementation
+ * Theme Options Customizer Implementation.
  *
- * Implement the Theme Customizer for 
- * Theme Settings.
+ * Implement the Theme Customizer for Theme Settings.
+ *
+ * @link http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/
  * 
- * @param 	object	$wp_customize	Object that holds the customizer data
- * 
- * @link	http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/	Otto
+ * @param WP_Customize_Manager $wp_customize Object that holds the customizer data.
  */
 function theme_slug_register_customizer_controls_basic( $wp_customize ){
 
@@ -51,19 +46,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Basic: Checkbox
-	 * Setting: Display Footer Credit Link
-	 * Sanitization: checkbox 
+	 * Basic Checkbox control.
+	 *
+	 * - Control: Basic: Checkbox
+	 * - Setting: Display Footer Credit Link
+	 * - Sanitization: checkbox
 	 * 
-	 * Register the core "checkbox" control to be 
-	 * used to configure the Display Footer Credit 
-	 * Link setting.
+	 * Register the core "checkbox" control to be used to configure the Display Footer Credit Link setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -80,18 +72,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Basic: Dropdown Pages 
-	 * Setting: Call-To-Action Link
-	 * Sanitization: dropdown_pages 
+	 * Basic Drop-down Pages control.
+	 *
+	 * - Control: Basic: Dropdown Pages
+	 * - Setting: Call-To-Action Link
+	 * - Sanitization: dropdown_pages
 	 * 
-	 * Register the core "dropdown-pages" control to be 
-	 * used to configure Call-To-Action Link setting.
+	 * Register the core "dropdown-pages" control to be used to configure Call-To-Action Link setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -108,18 +98,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Basic: Radio 
-	 * Setting: Menu Position
-	 * Sanitization: select 
+	 * Basic Radio Button control.
+	 *
+	 * - Control: Basic: Radio
+	 * - Setting: Menu Position
+	 * - Sanitization: select
 	 * 
-	 * Register the core "radio" control to be 
-	 * used to configure the Menu Position setting.
+	 * Register the core "radio" control to be used to configure the Menu Position setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -140,18 +128,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Basic: Select 
-	 * Setting: Color Scheme
-	 * Sanitization: select 
+	 * Basic Select control.
+	 *
+	 * - Control: Basic: Select
+	 * - Setting: Color Scheme
+	 * - Sanitization: select
 	 * 
-	 * Register the core "select" control to be 
-	 * used to configure the Color Scheme setting.
+	 * Register the core "select" control to be used to configure the Color Scheme setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -173,19 +159,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Basic: Text 
-	 * Setting: Footer Copyright Text
-	 * Sanitization: html  
+	 * Basic Text control.
+	 *
+	 * - Control: Basic: Text
+	 * - Setting: Footer Copyright Text
+	 * - Sanitization: html
 	 * 
-	 * Register the core "text" control to be 
-	 * used to configure the Footer Copyright 
-	 * Text setting.
+	 * Register the core "text" control to be used to configure the Footer Copyright Text setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -202,18 +185,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Basic: Textarea 
-	 * Setting: Custom CSS
-	 * Sanitization: css 
+	 * Basic Textarea control.
+	 *
+	 * - Control: Basic: Textarea
+	 * - Setting: Custom CSS
+	 * - Sanitization: css
 	 * 
-	 * Register the core "textarea" control to be 
-	 * used to configure the Custom CSS setting.
+	 * Register the core "textarea" control to be used to configure the Custom CSS setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -230,18 +211,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Text: Email 
-	 * Setting: Contact Email
-	 * Sanitization: email  
+	 * Basic Email control.
+	 *
+	 * - Control: Text: Email
+	 * - Setting: Contact Email
+	 * - Sanitization: email
 	 * 
-	 * Register the core "email" text control to be 
-	 * used to configure the Contact Email setting.
+	 * Register the core "email" text control to be used to configure the Contact Email setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -258,18 +237,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Text: Number 
-	 * Setting: Slide Count
-	 * Sanitization: number_absint
+	 * Basic Number control.
+	 *
+	 * - Control: Text: Number
+	 * - Setting: Slide Count
+	 * - Sanitization: number_absint
 	 * 
-	 * Register the core "number" text control to be 
-	 * used to configure the Slide Count setting.
+	 * Register the core "number" text control to be used to configure the Slide Count setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -286,22 +263,19 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Text: Tel 
-	 * Setting: Contact Telephone
-	 * Sanitization: number_range
+	 * Basic Telephone control.
+	 *
+	 * - Control: Text: Tel
+	 * - Setting: Contact Telephone
+	 * - Sanitization: number_range
 	 * 
-	 * Register the core "tel" text control to be 
-	 * used to configure the Contact Telephone setting.
+	 * Register the core "tel" text control to be used to configure the Contact Telephone setting.
 	 * 
-	 * A valid telephone number is either 10 or 12 digits, 
-	 * so the control is passed attributes for min 10 and 
-	 * max 12, with step = 2.
+	 * A valid telephone number is either 10 or 12 digits, so the control is passed attributes
+	 * for min 10 and max 12, with step = 2.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -323,18 +297,16 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	
 	
 	/**
-	 * Control: Text: URL 
-	 * Setting: Contact Link
-	 * Sanitization: url
+	 * Basic URL control.
+	 *
+	 * - Control: Text: URL
+	 * - Setting: Contact Link
+	 * - Sanitization: url
 	 * 
-	 * Register the core "url" text control to be 
-	 * used to configure the Contact Link setting.
+	 * Register the core "url" text control to be used to configure the Contact Link setting.
 	 * 
-	 * @uses	$wp_customize->add_control()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
-	 * @link	$wp_customize->add_control()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
-	 * 
-	 * @param	string	$id			Control ID
-	 * @param	array	$args		Arguments passed to the Control
+	 * @uses $wp_customize->add_control() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_control/
+	 * @link $wp_customize->add_control() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_control
 	 */
 	$wp_customize->add_control(
 		// $id
@@ -350,5 +322,6 @@ function theme_slug_register_customizer_controls_basic( $wp_customize ){
 	);
 
 }
-// Settings API options initilization and validation
+
+// Settings API options initilization and validation.
 add_action( 'customize_register', 'theme_slug_register_customizer_controls_basic' );


### PR DESCRIPTION
Docs wrapping, spacing, standards improvements. Within DocBlocks, elements should spaced apart, not tabbed apart. Plays much nicer with GitHub formatting too.

And since the @uses @link stuff in the multi-line comment above the control seem helpful, I left the opening line as a DocBlock style so IDE's could link up the methods.
