### PR TITLE
Docs standards for Sections

### DIFF
--- a/customizer/add-sections.php
+++ b/customizer/add-sections.php
@@ -2,28 +2,26 @@
 /**
  * Customizer: Add Sections
  *
- * This file demonstrates how to add 
- * Sections to the Customizer
+ * This file demonstrates how to add Sections to the Customizer
  * 
- * @package 	code-examples
- * @copyright	Copyright (c) 2015, WordPress Theme Review Team
- * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
+ * @package   code-examples
+ * @copyright Copyright (c) 2015, WordPress Theme Review Team
+ * @license   http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
  */
  
 
 /**
- * Theme Options Customizer Implementation
+ * Theme Options Customizer Implementation.
  *
- * Implement the Theme Customizer for 
- * Theme Settings.
+ * Implement the Theme Customizer for Theme Settings.
+ *
+ * @link http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/
  * 
- * @param 	object	$wp_customize	Object that holds the customizer data
- * 
- * @link	http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/	Otto
+ * @param WP_Customize_Manager $wp_customize Object that holds the customizer data.
  */
 function theme_slug_register_customizer_sections( $wp_customize ){
 
-	/**
+	/*
 	 * Failsafe is safe
 	 */
 	if ( ! isset( $wp_customize ) ) {
@@ -32,13 +30,10 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 	
 	
 	/**
-	 * Add Header Section for General Options
+	 * Add Header Section for General Options.
 	 * 
-	 * @uses	$wp_customize->add_section()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
-	 * @link	$wp_customize->add_section()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
-	 * 
-	 * @param	string	$id			Section ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Section
+	 * @uses $wp_customize->add_section() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
+	 * @link $wp_customize->add_section() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
 	 */
 	$wp_customize->add_section(
 		// $id
@@ -53,13 +48,10 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 	
 	
 	/**
-	 * Add Footer Section for General Options
+	 * Add Footer Section for General Options.
 	 * 
-	 * @uses	$wp_customize->add_section()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
-	 * @link	$wp_customize->add_section()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
-	 * 
-	 * @param	string	$id			Section ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Section
+	 * @uses $wp_customize->add_section() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
+	 * @link $wp_customize->add_section() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
 	 */
 	$wp_customize->add_section(
 		// $id
@@ -74,13 +66,10 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 	
 	
 	/**
-	 * Add Front Page Section for General Options
+	 * Add Front Page Section for General Options.
 	 * 
-	 * @uses	$wp_customize->add_section()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
-	 * @link	$wp_customize->add_section()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
-	 * 
-	 * @param	string	$id			Section ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Section
+	 * @uses $wp_customize->add_section() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
+	 * @link $wp_customize->add_section() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
 	 */
 	$wp_customize->add_section(
 		// $id
@@ -95,13 +84,10 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 	
 	
 	/**
-	 * Add Color Section for Color Options
+	 * Add Color Section for Color Options.
 	 * 
-	 * @uses	$wp_customize->add_section()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
-	 * @link	$wp_customize->add_section()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
-	 * 
-	 * @param	string	$id			Section ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Section
+	 * @uses $wp_customize->add_section() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
+	 * @link $wp_customize->add_section() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
 	 */
 	$wp_customize->add_section(
 		// $id
@@ -116,13 +102,10 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 	
 	
 	/**
-	 * Add Layout Section for Layout Options
+	 * Add Layout Section for Layout Options.
 	 * 
-	 * @uses	$wp_customize->add_section()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
-	 * @link	$wp_customize->add_section()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
-	 * 
-	 * @param	string	$id			Section ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Section
+	 * @uses $wp_customize->add_section() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
+	 * @link $wp_customize->add_section() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
 	 */
 	$wp_customize->add_section(
 		// $id
@@ -137,13 +120,10 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 	
 	
 	/**
-	 * Add CSS Section for Advanced Options
+	 * Add CSS Section for Advanced Options.
 	 * 
-	 * @uses	$wp_customize->add_section()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
-	 * @link	$wp_customize->add_section()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
-	 * 
-	 * @param	string	$id			Section ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Section
+	 * @uses $wp_customize->add_section() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_section/
+	 * @link $wp_customize->add_section() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_section
 	 */
 	$wp_customize->add_section(
 		// $id
@@ -155,7 +135,7 @@ function theme_slug_register_customizer_sections( $wp_customize ){
 			'panel'			=> 'theme_slug_panel_advanced'
 		)
 	);
-
 }
-// Settings API options initilization and validation
+
+// Settings API options initilization and validation.
 add_action( 'customize_register', 'theme_slug_register_customizer_sections' );


### PR DESCRIPTION
Docs wrapping, spacing, standards improvements. Within DocBlocks, elements should spaced apart, not tabbed apart. Plays much nicer with GitHub formatting too.

And since the @uses @link stuff in the multi-line comment above the control seem helpful, I left the opening line as a DocBlock style so IDE's could link up the methods.