### PR TITLE
Docs standards for Settings

### DIFF
--- a/customizer/add-settings.php
+++ b/customizer/add-settings.php
@@ -2,28 +2,26 @@
 /**
  * Customizer: Add Settings
  *
- * This file demonstrates how to add 
- * Settings to the Customizer
+ * This file demonstrates how to add Settings to the Customizer.
  * 
- * @package 	code-examples
- * @copyright	Copyright (c) 2015, WordPress Theme Review Team
- * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
+ * @package   code-examples
+ * @copyright Copyright (c) 2015, WordPress Theme Review Team
+ * @license   http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
  */
  
 
 /**
- * Theme Options Customizer Implementation
+ * Theme Options Customizer Implementation.
  *
- * Implement the Theme Customizer for 
- * Theme Settings.
- * 
- * @param 	object	$wp_customize	Object that holds the customizer data
- * 
- * @link	http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/	Otto
+ * Implement the Theme Customizer for Theme Settings.
+ *
+ * @link http://ottopress.com/2012/how-to-leverage-the-theme-customizer-in-your-own-themes/
+ *
+ * @param WP_Customize_Manager $wp_customize Object that holds the customizer data.
  */
 function theme_slug_register_customizer_settings( $wp_customize ){
 
-	/**
+	/*
 	 * Failsafe is safe
 	 */
 	if ( ! isset( $wp_customize ) ) {
@@ -32,18 +30,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Blog Layout 
-	 * Control: radio-image 
-	 * Sanitization: select 
+	 * Blog Layout setting example.
+	 *
+	 * - Setting: Blog Layout
+	 * - Control: radio-image
+	 * - Sanitization: select
 	 * 
-	 * Uses a custom radio-image control to configure 
-	 * the Blog Layout setting.
+	 * Uses a custom radio-image control to configure the Blog Layout setting.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -59,19 +55,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Call-To-Action Link
-	 * Control: dropdown pages
-	 * Sanitization: dropdown_pages
+	 * Call-To-Action Link setting example.
+	 *
+	 * - Setting: Call-To-Action Link
+	 * - Control: dropdown pages
+	 * - Sanitization: dropdown_pages
 	 * 
-	 * Uses a dropdown pages select to configure 
-	 * the page link for a front page Call-To-Action 
-	 * button.
+	 * Uses a dropdown pages select to configure the page link for a front page Call-To-Action button.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -87,19 +80,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Color Scheme
-	 * Control: select
-	 * Sanitization: select
+	 * Color Scheme setting example.
+	 *
+	 * - Setting: Color Scheme
+	 * - Control: select
+	 * - Sanitization: select
 	 * 
-	 * Uses a dropdown select to configure the
-	 * Theme color scheme, from a defined list 
-	 * of valid color choices.
+	 * Uses a dropdown select to configure the Theme color scheme, from a defined list of valid color choices.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -115,19 +105,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Contact Email 
-	 * Control: email 
-	 * Sanitization: email 
+	 * Contact Email setting example.
+	 *
+	 * - Setting: Contact Email
+	 * - Control: email
+	 * - Sanitization: email
 	 * 
-	 * Uses an email text field to configure the
-	 * user's contact email address displayed 
-	 * in the site footer.
+	 * Uses an email text field to configure the user's contact email address displayed in the site footer.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -143,19 +130,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Contact Link 
-	 * Control: url 
-	 * Sanitization: url 
+	 * Contact Link setting example.
+	 *
+	 * - Setting: Contact Link
+	 * - Control: url
+	 * - Sanitization: url
 	 * 
-	 * Uses a URL text field to configure the
-	 * user's contact link URL displayed 
-	 * in the site footer.
+	 * Uses a URL text field to configure the user's contact link URL displayed in the site footer.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -171,19 +155,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Contact Telephone 
-	 * Control: tel 
-	 * Sanitization: number_range 
+	 * Contact Telephone setting example.
+	 *
+	 * - Setting: Contact Telephone
+	 * - Control: tel
+	 * - Sanitization: number_range
 	 * 
-	 * Uses a tel text field to configure the
-	 * user's contact telephone number displayed 
-	 * in the site footer.
+	 * Uses a tel text field to configure the user's contact telephone number displayed in the site footer.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -199,19 +180,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Custom CSS
-	 * Control: textarea
-	 * Sanitization: css
+	 * Custom CSS setting example.
+	 *
+	 * - Setting: Custom CSS
+	 * - Control: textarea
+	 * - Sanitization: css
 	 * 
-	 * Uses a textarea to configure the
-	 * user-defined custom CSS for the 
-	 * Theme.
+	 * Uses a textarea to configure the user-defined custom CSS for the Theme.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -227,19 +205,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Display Footer Credit Link 
-	 * Control: checkbox 
-	 * Sanitization: checkbox
+	 * Display Footer Credit Link setting example.
+	 *
+	 * - Setting: Display Footer Credit Link
+	 * - Control: checkbox
+	 * - Sanitization: checkbox
 	 * 
-	 * Uses a checkbox to configure the
-	 * display of the Theme developer's 
-	 * footer credit link.
+	 * Uses a checkbox to configure the display of the Theme developer's footer credit link.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -255,19 +230,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Footer Copyright Text 
-	 * Control: text 
-	 * Sanitization: html 
+	 * Footer Copyright Text setting example.
+	 *
+	 * - Setting: Footer Copyright Text
+	 * - Control: text
+	 * - Sanitization: html
 	 * 
-	 * Uses a text field to configure the
-	 * user's copyright text displayed 
-	 * in the site footer.
+	 * Uses a text field to configure the user's copyright text displayed in the site footer.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -283,18 +255,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Link Color
-	 * Control: WP_Customize_Color_Control
-	 * Sanitization: hex_color
+	 * Link Color setting example.
+	 *
+	 * - Setting: Link Color
+	 * - Control: WP_Customize_Color_Control
+	 * - Sanitization: hex_color
 	 * 
-	 * Uses a color wheel to configure 
-	 * the Link Color setting.
+	 * Uses a color wheel to configure the Link Color setting.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -310,19 +280,17 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Menu Position 
-	 * Control: select
-	 * Sanitization: select
+	 * Menu Position setting example.
+	 *
+	 * - Setting: Menu Position
+	 * - Control: select
+	 * - Sanitization: select
 	 * 
-	 * Uses a radio select to configure the
-	 * position of the primary nav menu, either
-	 * above or below the header image.
+	 * Uses a radio select to configure the position of the primary nav menu, either above
+	 * or below the header image.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -338,19 +306,16 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Site Logo
-	 * Control: WP_Customize_Image_Control
-	 * Sanitization: image
+	 * Site Logo setting example.
+	 *
+	 * - Setting: Site Logo
+	 * - Control: WP_Customize_Image_Control
+	 * - Sanitization: image
 	 * 
-	 * Uses the media manager to upload and 
-	 * select an image to be used as the 
-	 * site logo.
+	 * Uses the media manager to upload and select an image to be used as the site logo.
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -366,19 +331,17 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 	
 	
 	/**
-	 * Setting: Slide Count
-	 * Control: number
-	 * Sanitization: number_absint
+	 * Slide Count setting example.
+	 *
+	 * - Setting: Slide Count
+	 * - Control: number
+	 * - Sanitization: number_absint
 	 * 
-	 * Uses a number type text input to configure 
-	 * the number of sticky posts to display as 
-	 * slides in the front page slider
+	 * Uses a number type text input to configure the number of sticky posts to display
+	 * as slides in the front page slider
 	 * 
-	 * @uses	$wp_customize->add_setting()	https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
-	 * @link	$wp_customize->add_setting()	https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
-	 * 
-	 * @param	string	$id			Setting ID. Passed to $wp_customize->add_control()
-	 * @param	array	$args		Arguments passed to the Setting
+	 * @uses $wp_customize->add_setting() https://developer.wordpress.org/reference/classes/wp_customize_manager/add_setting/
+	 * @link $wp_customize->add_setting() https://codex.wordpress.org/Class_Reference/WP_Customize_Manager/add_setting
 	 */
 	$wp_customize->add_setting(
 		// $id
@@ -391,7 +354,7 @@ function theme_slug_register_customizer_settings( $wp_customize ){
 			'sanitize_callback'	=> 'theme_slug_sanitize_number_absint'
 		)
 	);
-
 }
-// Settings API options initilization and validation
+
+// Settings API options initilization and validation.
 add_action( 'customize_register', 'theme_slug_register_customizer_settings' );


### PR DESCRIPTION
Docs wrapping, spacing, standards improvements. Within DocBlocks, elements should spaced apart, not tabbed apart. Plays much nicer with GitHub formatting too.

And since the @uses @link stuff in the multi-line comment above the control seem helpful, I left the opening line as a DocBlock style so IDE's could link up the methods.